### PR TITLE
src: video: prevent size and interval duplicates

### DIFF
--- a/src/video/types.rs
+++ b/src/video/types.rs
@@ -11,7 +11,7 @@ pub enum VideoSourceType {
     Local(VideoSourceLocal),
 }
 
-#[derive(Apiv2Schema, Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Apiv2Schema, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub enum VideoEncodeType {
     UNKNOWN(String),
     H265,
@@ -35,14 +35,14 @@ pub struct Format {
     pub sizes: Vec<Size>,
 }
 
-#[derive(Apiv2Schema, Clone, Debug, Deserialize, Serialize)]
+#[derive(Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct Size {
     pub width: u32,
     pub height: u32,
     pub intervals: Vec<FrameInterval>,
 }
 
-#[derive(Apiv2Schema, Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[derive(Apiv2Schema, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize)]
 pub struct FrameInterval {
     pub numerator: u32,
     pub denominator: u32,

--- a/src/video/video_source_local.rs
+++ b/src/video/video_source_local.rs
@@ -221,6 +221,14 @@ impl VideoSource for VideoSourceLocal {
                     }
                 }
             }
+
+            sizes.sort();
+            sizes.dedup();
+            sizes.iter_mut().for_each(|s| {
+                s.intervals.sort();
+                s.intervals.dedup();
+            });
+
             formats.push(Format {
                 encode: VideoEncodeType::from_str(v4l_format.fourcc.str().unwrap()),
                 sizes,


### PR DESCRIPTION
This commit prevents duplicated sizes and intervals (as reported on #12) from being accepted on video data structures.

Should fix #12.

---

I don't know enough of Rust yet to say if this approach is good, but I can say it works. Anyway, let me know how we can improve it =)